### PR TITLE
README.md: Remove dead AUR link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ For semi-official builds and third-party packages of the official mpv please see
 
 Packages for this particular fork are available for the following distributions:
 
-- [ArchLinux (AUR)](https://aur.archlinux.org/packages/mpvhq-git/)
-
 - [CRUX (6c37/mpvhq)](https://github.com/6c37/crux-ports-git/tree/master/mpvhq)
 
 - [Gentoo (haasn/gentoo-overlay)](https://github.com/haasn/gentoo-overlay/blob/master/media-video/mpv/mpv-9999.ebuild)


### PR DESCRIPTION
The port is neither in the old AUR or the new AUR4.

EDIT: Spelled dead wrong, embarrassing!!
